### PR TITLE
Update README.md - Minor clarification wrt "install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Verify it by `edid-decode`:
 
     edid-decode EDID.bin
 
-Install `EDID.bin` by [write-edid](https://github.com/linuxhw/write-edid) or [edid-rw](https://github.com/bulletmark/edid-rw).
+Install (flash/upload it to the monitor) `EDID.bin` by [write-edid](https://github.com/linuxhw/write-edid) or [edid-rw](https://github.com/bulletmark/edid-rw).
 
 How to regenerate data
 ----------------------


### PR DESCRIPTION
Minor clarification that "Install" means flashing the edid.bin to the actual monitor in this context.

Initially I misunderstood this, because my goal was to use the edid.bin as a kernel parameter and not to flash it to actual hardware since my monitor was only misbehaving using Linux. Windows worked just fine. I wanted to "install" it to my initrd.img and nothing more